### PR TITLE
Remove all uses of UnsafeCell

### DIFF
--- a/src/control/cio.rs
+++ b/src/control/cio.rs
@@ -56,7 +56,7 @@ pub trait CIO {
     /// Removes a peer - This will trigger an error being
     /// reported at the next poll time, clients should wait
     /// for this to occur before internally removing the peer.
-    fn remove_peer(&mut self, peer: PID);
+    fn remove_peer(&self, peer: PID);
 
     /// Flushes events on the given vec of peers
     fn flush_peers(&mut self, peers: Vec<PID>);
@@ -166,7 +166,7 @@ pub mod test {
             }
         }
 
-        fn remove_peer(&mut self, peer: PID) {
+        fn remove_peer(&self, peer: PID) {
             let mut d = self.data.lock().unwrap();
             d.peers.remove(&peer);
         }

--- a/src/throttle.rs
+++ b/src/throttle.rs
@@ -1,4 +1,4 @@
-use std::cell::UnsafeCell;
+use std::cell::RefCell;
 use std::rc::Rc;
 use amy::Registrar;
 use std::collections::HashSet;
@@ -10,8 +10,8 @@ use std::collections::HashSet;
 pub struct Throttler {
     id: usize,
     fid: usize,
-    dl_data: Rc<UnsafeCell<ThrottleData>>,
-    ul_data: Rc<UnsafeCell<ThrottleData>>,
+    dl_data: Rc<RefCell<ThrottleData>>,
+    ul_data: Rc<RefCell<ThrottleData>>,
 }
 
 const URATE: usize = 15;
@@ -33,8 +33,8 @@ impl Throttler {
         Throttler {
             id,
             fid,
-            ul_data: Rc::new(UnsafeCell::new(ut)),
-            dl_data: Rc::new(UnsafeCell::new(dt)),
+            ul_data: Rc::new(RefCell::new(ut)),
+            dl_data: Rc::new(RefCell::new(dt)),
         }
     }
 
@@ -45,47 +45,47 @@ impl Throttler {
         Throttler {
             id: 0,
             fid: 0,
-            ul_data: Rc::new(UnsafeCell::new(ut)),
-            dl_data: Rc::new(UnsafeCell::new(dt)),
+            ul_data: Rc::new(RefCell::new(ut)),
+            dl_data: Rc::new(RefCell::new(dt)),
         }
     }
 
-    pub fn update(&mut self) -> (u64, u64) {
-        let ul = self.ul_data().add_tokens();
-        let dl = self.dl_data().add_tokens();
+    pub fn update(&self) -> (u64, u64) {
+        let ul = self.ul_data.borrow_mut().add_tokens();
+        let dl = self.dl_data.borrow_mut().add_tokens();
         (ul, dl)
     }
 
     pub fn get_throttle(&self, id: usize) -> Throttle {
         Throttle {
             ul_data: self.ul_data.clone(),
-            ul_tier: Rc::new(UnsafeCell::new(ThrottleData::new(
+            ul_tier: Rc::new(RefCell::new(ThrottleData::new(
                 None,
-                self.ul_data().max_tokens,
+                self.ul_data.borrow().max_tokens,
             ))),
             dl_data: self.dl_data.clone(),
-            dl_tier: Rc::new(UnsafeCell::new(ThrottleData::new(
+            dl_tier: Rc::new(RefCell::new(ThrottleData::new(
                 None,
-                self.dl_data().max_tokens,
+                self.dl_data.borrow().max_tokens,
             ))),
             id,
         }
     }
 
     pub fn ul_rate(&mut self) -> Option<i64> {
-        self.ul_data().rate
+        self.ul_data.borrow().rate
     }
 
     pub fn dl_rate(&mut self) -> Option<i64> {
-        self.dl_data().rate
+        self.dl_data.borrow().rate
     }
 
     pub fn set_ul_rate(&mut self, rate: Option<i64>) {
-        self.ul_data().rate = rate;
+        self.ul_data.borrow_mut().rate = rate;
     }
 
     pub fn set_dl_rate(&mut self, rate: Option<i64>) {
-        self.dl_data().rate = rate;
+        self.dl_data.borrow_mut().rate = rate;
     }
 
     pub fn id(&self) -> usize {
@@ -97,19 +97,15 @@ impl Throttler {
     }
 
     pub fn flush_ul(&mut self) -> Vec<usize> {
-        self.ul_data().throttled.drain().collect()
+        let mut ul_data = self.ul_data.borrow_mut();
+        let flushed = ul_data.throttled.drain().collect();
+        flushed
     }
 
     pub fn flush_dl(&mut self) -> Vec<usize> {
-        self.dl_data().throttled.drain().collect()
-    }
-
-    fn ul_data<'f>(&self) -> &'f mut ThrottleData {
-        unsafe { self.ul_data.get().as_mut().unwrap() }
-    }
-
-    fn dl_data<'f>(&self) -> &'f mut ThrottleData {
-        unsafe { self.dl_data.get().as_mut().unwrap() }
+        let mut dl_data = self.dl_data.borrow_mut();
+        let flushed = dl_data.throttled.drain().collect();
+        flushed
     }
 }
 
@@ -128,10 +124,10 @@ struct ThrottleData {
 #[derive(Clone)]
 pub struct Throttle {
     pub id: usize,
-    ul_tier: Rc<UnsafeCell<ThrottleData>>,
-    dl_tier: Rc<UnsafeCell<ThrottleData>>,
-    ul_data: Rc<UnsafeCell<ThrottleData>>,
-    dl_data: Rc<UnsafeCell<ThrottleData>>,
+    ul_tier: Rc<RefCell<ThrottleData>>,
+    dl_tier: Rc<RefCell<ThrottleData>>,
+    ul_data: Rc<RefCell<ThrottleData>>,
+    dl_data: Rc<RefCell<ThrottleData>>,
 }
 
 unsafe impl Send for Throttle {}
@@ -148,100 +144,84 @@ impl Throttle {
     }
 
     pub fn get_bytes_dl(&mut self, amnt: usize) -> Result<(), ()> {
-        while self.dl_tier().epoch != self.dl_data().epoch {
-            self.dl_tier().add_tokens();
+        while self.dl_tier.borrow().epoch != self.dl_data.borrow().epoch {
+            self.dl_tier.borrow_mut().add_tokens();
         }
         if self.dl_rate() == Some(-1) {
-            self.dl_tier().last_used += amnt as u64;
-            self.dl_data().last_used += amnt as u64;
+            self.dl_tier.borrow_mut().last_used += amnt as u64;
+            self.dl_data.borrow_mut().last_used += amnt as u64;
             return Ok(());
         }
-        let pres = self.dl_data().get_tokens(amnt);
+        let pres = self.dl_data.borrow_mut().get_tokens(amnt);
         if pres.is_err() {
-            self.dl_data().throttled.insert(self.id);
+            self.dl_data.borrow_mut().throttled.insert(self.id);
             return Err(());
         }
 
-        let res = self.dl_tier().get_tokens(amnt);
+        let res = self.dl_tier.borrow_mut().get_tokens(amnt);
         if res.is_err() {
-            self.dl_data().restore_tokens(amnt);
-            self.dl_data().throttled.insert(self.id);
+            self.dl_data.borrow_mut().restore_tokens(amnt);
+            self.dl_data.borrow_mut().throttled.insert(self.id);
             return Err(());
         }
         Ok(())
     }
 
     pub fn get_bytes_ul(&mut self, amnt: usize) -> Result<(), ()> {
-        while self.ul_tier().epoch != self.ul_data().epoch {
-            self.ul_tier().add_tokens();
+        while self.ul_tier.borrow().epoch != self.ul_data.borrow().epoch {
+            self.ul_tier.borrow_mut().add_tokens();
         }
         if self.ul_rate() == Some(-1) {
-            self.ul_tier().last_used += amnt as u64;
-            self.ul_data().last_used += amnt as u64;
+            self.ul_tier.borrow_mut().last_used += amnt as u64;
+            self.ul_data.borrow_mut().last_used += amnt as u64;
             return Ok(());
         }
-        let pres = self.ul_data().get_tokens(amnt);
+        let pres = self.ul_data.borrow_mut().get_tokens(amnt);
         if pres.is_err() {
-            self.ul_data().throttled.insert(self.id);
+            self.ul_data.borrow_mut().throttled.insert(self.id);
             return Err(());
         }
 
-        let res = self.ul_tier().get_tokens(amnt);
+        let res = self.ul_tier.borrow_mut().get_tokens(amnt);
         if res.is_err() {
-            self.ul_data().restore_tokens(amnt);
-            self.ul_data().throttled.insert(self.id);
+            self.ul_data.borrow_mut().restore_tokens(amnt);
+            self.ul_data.borrow_mut().throttled.insert(self.id);
             return Err(());
         }
         Ok(())
     }
 
     pub fn ul_rate(&self) -> Option<i64> {
-        self.ul_tier().rate
+        self.ul_tier.borrow_mut().rate
     }
 
     pub fn dl_rate(&self) -> Option<i64> {
-        self.dl_tier().rate
+        self.dl_tier.borrow_mut().rate
     }
 
     pub fn set_ul_rate(&mut self, rate: Option<i64>) {
-        self.ul_tier().rate = rate;
+        self.ul_tier.borrow_mut().rate = rate;
     }
 
     pub fn set_dl_rate(&mut self, rate: Option<i64>) {
-        self.dl_tier().rate = rate;
+        self.dl_tier.borrow_mut().rate = rate;
     }
 
     pub fn restore_bytes_dl(&mut self, amnt: usize) {
-        self.dl_data().restore_tokens(amnt);
-        self.dl_tier().restore_tokens(amnt);
+        self.dl_data.borrow_mut().restore_tokens(amnt);
+        self.dl_tier.borrow_mut().restore_tokens(amnt);
     }
 
     pub fn restore_bytes_ul(&mut self, amnt: usize) {
-        self.ul_data().restore_tokens(amnt);
-        self.ul_tier().restore_tokens(amnt);
-    }
-
-    fn ul_data(&self) -> &'static mut ThrottleData {
-        unsafe { self.ul_data.get().as_mut().unwrap() }
-    }
-
-    fn ul_tier(&self) -> &'static mut ThrottleData {
-        unsafe { self.ul_tier.get().as_mut().unwrap() }
-    }
-
-    fn dl_data(&self) -> &'static mut ThrottleData {
-        unsafe { self.dl_data.get().as_mut().unwrap() }
-    }
-
-    fn dl_tier(&self) -> &'static mut ThrottleData {
-        unsafe { self.dl_tier.get().as_mut().unwrap() }
+        self.ul_data.borrow_mut().restore_tokens(amnt);
+        self.ul_tier.borrow_mut().restore_tokens(amnt);
     }
 }
 
 impl Drop for Throttle {
     fn drop(&mut self) {
-        self.ul_data().throttled.remove(&self.id);
-        self.dl_data().throttled.remove(&self.id);
+        self.ul_data.borrow_mut().throttled.remove(&self.id);
+        self.dl_data.borrow_mut().throttled.remove(&self.id);
     }
 }
 


### PR DESCRIPTION
This PR replaces all uses of UnsafeCell with RefCell. While this makes the code slightly more verbose, it removes an enormous amount of potential undefined behavior.

In particular, methods like `fn d(&self) -> &'static mut ACIOData` are incredibly unsafe. Each and every call to one of these accessor methods is potential UB, without even an unsafe block in the caller to warn the reader.