### PR TITLE
Add dev and prod Dockerfiles

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,30 @@
+FROM rust:latest as build
+
+ARG SYNAPSE_VERSION=master
+ARG SYNAPSE_GIT_SRC=https://github.com/Luminarys/synapse.git
+
+WORKDIR /usr/src
+
+RUN git clone $SYNAPSE_GIT_SRC . \
+  && [ "$SYNAPSE_VERSION" != 'master' ] && git checkout tags/$SYNAPSE_VERSION || git checkout master \
+  ;
+RUN cargo build --release --all
+
+FROM debian:latest
+
+ENV SYNAPSE_HOME=/opt/synapse
+
+RUN apt-get update \
+  && apt-get -y install libssl1.1 \
+  && apt-get clean \
+  && rm -rf /var/lib/apt/lists/* \
+  && useradd --comment "Synapse" --home ${SYNAPSE_HOME} --shell /usr/sbin/nologin --system synapse \
+  && mkdir -p ${SYNAPSE_HOME} \
+  && chown synapse:synapse ${SYNAPSE_HOME} \
+  ;
+
+COPY --from=build /usr/src/target/release/synapse /usr/src/target/release/sycli /usr/local/bin/
+
+USER synapse
+WORKDIR $SYNAPSE_HOME
+CMD ["synapse"]

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,0 +1,11 @@
+FROM rust:latest
+
+WORKDIR /usr/src
+
+COPY . .
+
+RUN cargo build --release --all \
+  && cargo install \
+  && cargo install --path ./sycli/
+
+CMD ["synapse"]

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,9 @@
+.PHONY: build dev
+
+docker_tag := synapse
+
+dev:
+	docker build -t $(docker_tag)-dev -f Dockerfile.dev .
+
+build:
+	docker build -t $(docker_tag) .


### PR DESCRIPTION
Added Dockerfiles suitable for development and official release building.

And a Makefile with targets for automation of docker image building.

Both may require some fine tuning, but should be a good starting point.

Refs: Luminarys/synapse/issues/74