### PR TITLE
Remove Send impl for Throttle

### DIFF
--- a/src/control/mod.rs
+++ b/src/control/mod.rs
@@ -341,7 +341,12 @@ impl<T: cio::CIO> Control<T> {
         if let Some(tid) = self.hash_idx.get(&msg.hash).cloned() {
             let id = msg.id;
             let rsv = msg.rsv;
-            self.add_inc_peer(tid, peer::PeerConn::new_incoming(msg.conn, msg.reader).unwrap(), id, rsv);
+            match peer::PeerConn::new_incoming(msg.conn, msg.reader) {
+                Ok(p) => self.add_inc_peer(tid, p, id, rsv),
+                Err(e) => {
+                    error!("Failed to create peer connection: {:?}", e);
+                }
+            };
         } else {
             let h = msg.hash;
             error!("Couldn't add peer, torrent with hash {:?} doesn't exist", h);

--- a/src/control/mod.rs
+++ b/src/control/mod.rs
@@ -256,7 +256,7 @@ impl<T: cio::CIO> Control<T> {
                 return true;
             }
             cio::Event::Listener(Ok(e)) => {
-                self.handle_lst_ev(e);
+                self.handle_lst_ev(*e);
             }
             cio::Event::Listener(Err(e)) => {
                 error!("listener error: {:?}", e);
@@ -336,12 +336,12 @@ impl<T: cio::CIO> Control<T> {
         }
     }
 
-    fn handle_lst_ev(&mut self, msg: Box<listener::Message>) {
+    fn handle_lst_ev(&mut self, msg: listener::Message) {
         debug!("Adding peer for torrent with hash {:?}!", msg.hash);
         if let Some(tid) = self.hash_idx.get(&msg.hash).cloned() {
             let id = msg.id;
             let rsv = msg.rsv;
-            self.add_inc_peer(tid, msg.peer, id, rsv);
+            self.add_inc_peer(tid, peer::PeerConn::new_incoming(msg.conn, msg.reader).unwrap(), id, rsv);
         } else {
             let h = msg.hash;
             error!("Couldn't add peer, torrent with hash {:?} doesn't exist", h);

--- a/src/throttle.rs
+++ b/src/throttle.rs
@@ -130,8 +130,6 @@ pub struct Throttle {
     dl_data: Rc<RefCell<ThrottleData>>,
 }
 
-unsafe impl Send for Throttle {}
-
 impl Throttle {
     pub fn new_sibling(&self, id: usize) -> Throttle {
         Throttle {

--- a/src/torrent/peer/mod.rs
+++ b/src/torrent/peer/mod.rs
@@ -1,5 +1,5 @@
-mod reader;
-mod writer;
+pub mod reader;
+pub mod writer;
 mod message;
 
 use std::net::SocketAddr;
@@ -117,8 +117,10 @@ impl PeerConn {
 
     /// Creates a peer where we are acting as the server.
     /// Once the handshake is received, set_torrent should be called.
-    pub fn new_incoming(sock: TcpStream) -> io::Result<PeerConn> {
-        Ok(PeerConn::new(Socket::from_stream(sock)?))
+    pub fn new_incoming(sock: TcpStream, reader: Reader) -> io::Result<PeerConn> {
+        let mut peer = PeerConn::new(Socket::from_stream(sock)?);
+        peer.reader = reader;
+        Ok(peer)
     }
 
     pub fn writable(&mut self) -> io::Result<()> {


### PR DESCRIPTION
While the Rc-wrapped data only appears to be used from one
thread, this Send impl makes it easy to accidentally cause UB
if Throttle is ever used before sending it across a channel.

Instead, only the TcpStream and Reader for a given peer are send across
a channel. The PeerConn and its internal Throttle are constructed on
the other side, allowing an Rc to be used without any potential for UB