### PR TITLE
Require T: Send + Sync for AView's Send impl

### DIFF
--- a/src/util/aview.rs
+++ b/src/util/aview.rs
@@ -56,7 +56,7 @@ impl<T> Clone for AView<T> {
     }
 }
 
-unsafe impl<T: Send> Send for AView<T> {}
+unsafe impl<T: Send + Sync> Send for AView<T> {}
 unsafe impl<T: Send + Sync> Sync for AView<T> {}
 
 impl<T> Drop for AView<T> {


### PR DESCRIPTION
In terms of thread-safety, an AView is logically equivalent to an Arc.
Since Arc requires that its contents be 'Send + Sync' in order for Arc
to be 'Send', AView should as well.