### PR TITLE
add musl docker image build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+*
+!target/x86_64-unknown-linux-musl/release/synapse
+!target/x86_64-unknown-linux-musl/release/sycli
+!example_config.toml

--- a/Dockerfile.musl
+++ b/Dockerfile.musl
@@ -1,0 +1,21 @@
+FROM alpine:latest
+
+RUN apk add --no-cache ca-certificates
+RUN adduser synapse -Du 1000 -h /synapse
+
+ADD target/x86_64-unknown-linux-musl/release/synapse /usr/bin
+ADD target/x86_64-unknown-linux-musl/release/sycli /usr/bin
+
+EXPOSE 16493 \
+       8412 \
+       16362 \
+       16309
+
+USER synapse
+RUN mkdir -p ~/.config
+ADD example_config.toml /synapse/.config/synapse.toml
+RUN sed -i "s/directory \= \".\/\"/directory \= \"\/synapse\/downloads\""/ ~/.config/synapse.toml
+
+VOLUME /synapse/downloads
+
+CMD ["synapse"]

--- a/Dockerfile.musl
+++ b/Dockerfile.musl
@@ -14,7 +14,8 @@ EXPOSE 16493 \
 USER synapse
 RUN mkdir -p ~/.config
 ADD example_config.toml /synapse/.config/synapse.toml
-RUN sed -i "s/directory \= \".\/\"/directory \= \"\/synapse\/downloads\""/ ~/.config/synapse.toml
+RUN sed -i "s/directory \= \".\/\"/directory \= \"\/synapse\/downloads\"/" ~/.config/synapse.toml && \
+    sed -i "s/local \= true/local \= false/" ~/.config/synapse.toml
 
 VOLUME /synapse/downloads
 

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,32 @@
+NAME=synapse
+VERSION=$(shell git rev-parse HEAD)
+SEMVER_VERSION=$(shell grep version Cargo.toml | awk -F"\"" '{print $$2}' | head -n 1)
+REPO=luminarys
+
+compile:
+	docker run --rm \
+		-v cargo-cache:/root/.cargo \
+		-v $$PWD:/volume \
+		-w /volume \
+		-it clux/muslrust:stable \
+		cargo build --release --all
+	sudo chown $$USER:$$USER -R target
+	strip target/x86_64-unknown-linux-musl/release/synapse
+	strip target/x86_64-unknown-linux-musl/release/sycli
+
+build:
+	docker build -t $(REPO)/$(NAME):$(VERSION) . -f Dockerfile.musl
+
+run:
+	docker run -v ~/Downloads/synapse:/synapse/downloads -t $(REPO)/$(NAME):$(VERSION)
+
+tag-latest: build
+	docker tag $(REPO)/$(NAME):$(VERSION) $(REPO)/$(NAME):latest
+	docker push $(REPO)/$(NAME):latest
+
+tag-semver: build
+	if curl -sSL https://registry.hub.docker.com/v1/repositories/$(REPO)/$(NAME)/tags | jq -r ".[].name" | grep -q $(SEMVER_VERSION); then \
+		echo "Tag $(SEMVER_VERSION) already exists" && exit 1 ;\
+	fi
+	docker tag $(REPO)/$(NAME):$(VERSION) $(REPO)/$(NAME):$(SEMVER_VERSION)
+	docker push $(REPO)/$(NAME):$(SEMVER_VERSION)

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,11 @@ build:
 	docker build -t $(REPO)/$(NAME):$(VERSION) . -f Dockerfile.musl
 
 run:
-	docker run -v ~/Downloads/synapse:/synapse/downloads -t $(REPO)/$(NAME):$(VERSION)
+	mkdir -p ~/Downloads/synapse
+	sudo chown 1000:1000 -R ~/Downloads/synapse
+	docker run \
+		-v ~/Downloads/synapse:/synapse/downloads \
+		-it $(REPO)/$(NAME):$(VERSION) sh
 
 tag-latest: build
 	docker tag $(REPO)/$(NAME):$(VERSION) $(REPO)/$(NAME):latest

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ run:
 	sudo chown 1000:1000 -R ~/Downloads/synapse
 	docker run \
 		-v ~/Downloads/synapse:/synapse/downloads \
-		-it $(REPO)/$(NAME):$(VERSION) sh
+		-t $(REPO)/$(NAME):$(VERSION)
 
 tag-latest: build
 	docker tag $(REPO)/$(NAME):$(VERSION) $(REPO)/$(NAME):latest


### PR DESCRIPTION
A slightly different approach to #74 than #77 for a smaller image.

Uses [muslrust](https://github.com/clux/muslrust) for cross compiling for musl, and adds the static binaries into an alpine image:

```
REPOSITORY                      TAG                                        IMAGE ID            CREATED             SIZE
luminarys/synapse               latest                                     de4848aebac6        9 minutes ago       17.8MB
```

Think it handles download volumes and ports sufficiently? crt/pem files can be mounted over in the users homedir. Any other config changes can be done by inheriting from this image. Feels like sensible defaults to me.

The rest is my normal makefile template for these things. Trash as appropriate.

Side-discovery: docker needs a lowercase name in the organisation.