### PR TITLE
Fix setting User-Agent header

### DIFF
--- a/src/tracker/http/mod.rs
+++ b/src/tracker/http/mod.rs
@@ -263,7 +263,7 @@ impl Handler {
         }
 
         http_req.extend_from_slice(b" HTTP/1.1\r\n");
-        let user_agent = format!("User-Agent: {}/{}", "synapse", env!("CARGO_PKG_VERSION"));
+        let user_agent = format!("User-Agent: {}/{}\r\n", "synapse", env!("CARGO_PKG_VERSION"));
         http_req.extend_from_slice(user_agent.as_bytes());
         http_req.extend_from_slice(b"Connection: close\r\n");
         http_req.extend_from_slice(b"Host: ");
@@ -352,6 +352,8 @@ impl Handler {
 
         // Encode HTTP protocol
         http_req.extend_from_slice(b" HTTP/1.1\r\n");
+        let user_agent = format!("User-Agent: {}/{}\r\n", "synapse", env!("CARGO_PKG_VERSION"));
+        http_req.extend_from_slice(user_agent.as_bytes());
         // Don't keep alive
         http_req.extend_from_slice(b"Connection: close\r\n");
         // Encode host header


### PR DESCRIPTION
Added "\r\n" to the User-Agent string, since without it, it was combining the User-Agent and Connection strings to one line.

Also added the User-Agent to the new_announce function.  I'm not sure if it needs to stay in try_redirect, but it definitely needed to be added to new_announce for it to be sent to http trackers.