### PR TITLE
Load multiple trackers from magnet links

### DIFF
--- a/src/torrent/info.rs
+++ b/src/torrent/info.rs
@@ -113,11 +113,13 @@ impl Info {
             })
             .ok_or("No hash found in magnet")?;
 
-        let url_list: Vec<_> = url.query_pairs()
+        let mut url_list: Vec<_> = url.query_pairs()
             .filter(|&(ref k, _)| k == "tr")
             .filter_map(|(_, ref v)| Url::parse(v).ok())
             .map(Arc::new)
             .collect();
+        rand::thread_rng().shuffle(&mut url_list[..]);
+
         let name = url.query_pairs()
             .find(|&(ref k, _)| k == "dn")
             .map(|(_, ref v)| v.to_string())

--- a/src/torrent/info.rs
+++ b/src/torrent/info.rs
@@ -112,9 +112,12 @@ impl Info {
                 })
             })
             .ok_or("No hash found in magnet")?;
-        let announce = url.query_pairs()
-            .find(|&(ref k, _)| k == "tr")
-            .and_then(|(_, ref v)| Url::parse(v).ok().map(Arc::new));
+
+        let url_list: Vec<_> = url.query_pairs()
+            .filter(|&(ref k, _)| k == "tr")
+            .filter_map(|(_, ref v)| Url::parse(v).ok())
+            .map(Arc::new)
+            .collect();
         let name = url.query_pairs()
             .find(|&(ref k, _)| k == "dn")
             .map(|(_, ref v)| v.to_string())
@@ -123,7 +126,7 @@ impl Info {
             name,
             comment: None,
             creator: None,
-            announce,
+            announce: None,
             piece_len: 0,
             total_len: 0,
             hashes: vec![],
@@ -132,7 +135,7 @@ impl Info {
             private: false,
             be_name: None,
             piece_idx: vec![],
-            url_list: vec![],
+            url_list: vec![url_list]
         })
     }
 


### PR DESCRIPTION
[BEP-0009](http://www.bittorrent.org/beps/bep_0009.html) says multiple trackers are allowed in a magnet link, so with this commit I make sure they're all loaded into url_list. I just have some questions:
* Should the trackers be all put in the first tier as I did here, and if yes should they be randomized as in the announce-list in .torrent files?
* Is there any particular reason to have separate `announce` and `url_list` fields instead of a single `trackers`?