### PR TITLE
[WIP] Different directories for completed/downloading torrents

### DIFF
--- a/example_config.toml
+++ b/example_config.toml
@@ -35,6 +35,9 @@ bootstrap_node = "router.bittorrent.com:6881"
 session = "~/.local/share/synapse/"
 # Default download directory
 directory = "./"
+# Default directory for completed torrents
+# Empty to use the download directory
+completed = ""
 
 [net]
 # These max open limits should be set to be somewhat lower

--- a/src/config.rs
+++ b/src/config.rs
@@ -100,6 +100,8 @@ pub struct DiskConfig {
     pub session: String,
     #[serde(default = "default_directory_dir")]
     pub directory: String,
+    #[serde(default = "default_completed_dir")]
+    pub completed: Option<String>,
     #[serde(default = "default_validate")]
     pub validate: bool,
 }
@@ -187,8 +189,14 @@ impl Config {
             port: file.dht.port,
             bootstrap_node: addr,
         };
+
         file.disk.session = shellexpand::tilde(&file.disk.session).into();
         file.disk.directory = shellexpand::tilde(&file.disk.directory).into();
+        file.disk.completed = match file.disk.completed {
+            Some(ref dir) => Some(shellexpand::tilde(dir).to_string()),
+            None => None
+        };
+
         Config {
             port: file.port,
             max_dl: file.max_dl,
@@ -237,9 +245,15 @@ fn default_session_dir() -> String {
         .unwrap_or_else(|_| shellexpand::tilde("~/.local/share/synapse"))
         .into()
 }
+
 fn default_directory_dir() -> String {
     "./".into()
 }
+
+fn default_completed_dir() -> Option<String> {
+    None
+}
+
 fn default_validate() -> bool {
     true
 }
@@ -315,6 +329,7 @@ impl Default for DiskConfig {
         DiskConfig {
             session: default_session_dir(),
             directory: default_directory_dir(),
+            completed: default_completed_dir(),
             validate: default_validate(),
         }
     }

--- a/src/control/mod.rs
+++ b/src/control/mod.rs
@@ -377,7 +377,8 @@ impl<T: cio::CIO> Control<T> {
     fn add_torrent(
         &mut self,
         info: torrent::Info,
-        path: Option<String>,
+        comp_path: Option<String>,
+        dl_path: Option<String>,
         start: bool,
         import: bool,
         client: usize,
@@ -398,7 +399,8 @@ impl<T: cio::CIO> Control<T> {
         let throttle = self.throttler.get_throttle(tid);
         let t = Torrent::new(
             tid,
-            path,
+            comp_path,
+            dl_path,
             info,
             throttle,
             self.cio.new_handle(),
@@ -436,7 +438,7 @@ impl<T: cio::CIO> Control<T> {
                 import,
                 client,
                 serial,
-            } => self.add_torrent(info, path, start, import, client, serial),
+            } => self.add_torrent(info, None, None, start, import, client, serial),
             rpc::Message::UpdateFile {
                 id,
                 torrent_id,

--- a/src/disk/job.rs
+++ b/src/disk/job.rs
@@ -362,7 +362,14 @@ impl Request {
                 let mut fp = tpb.get(&from);
                 let mut tp = tpb2.get(&to);
                 fp.push(target.clone());
+
+                if !tp.exists() {
+                    debug!("{:?} does not exist, creating", tp);
+                    fs::create_dir_all(&tp)?;
+                }
+
                 tp.push(target);
+
                 match fs::rename(&fp, &tp) {
                     Ok(_) => {}
                     // Cross filesystem move, try to copy then delete

--- a/sycli/src/client.rs
+++ b/sycli/src/client.rs
@@ -4,7 +4,8 @@ use ws::protocol::Message as WSMessage;
 use serde_json;
 use url::Url;
 
-use rpc::message::{CMessage, SMessage, Version};
+use rpc;
+use rpc::message::{SMessage, CMessage, Version};
 
 use error::{ErrorKind, Result, ResultExt};
 
@@ -20,7 +21,10 @@ impl Client {
         let mut c = Client {
             ws: client,
             serial: 0,
-            version: Version { major: 0, minor: 0 },
+            version: Version {
+                major: rpc::MAJOR_VERSION,
+                minor: rpc::MINOR_VERSION
+            },
         };
 
         match c.recv()? {

--- a/sycli/src/client.rs
+++ b/sycli/src/client.rs
@@ -22,11 +22,24 @@ impl Client {
             serial: 0,
             version: Version { major: 0, minor: 0 },
         };
-        if let SMessage::RpcVersion(v) = c.recv()? {
-            c.version = v;
-            Ok(c)
-        } else {
-            bail!("Expected a version message on start!");
+
+        match c.recv()? {
+            SMessage::RpcVersion(v) => {
+                if c.version.major != v.major {
+                    bail!("RPC major version missmatch (server: {}, client: {})",
+                        v.major,
+                        c.version.major
+                    )
+                } else if c.version.minor < v.minor {
+                    bail!("RPC minor version missmatch (server: {}, client: {})",
+                        v.minor,
+                        c.version.minor
+                    )
+                } else {
+                    Ok(c)
+                }
+            },
+            _ => bail!("expected version message at start")
         }
     }
 

--- a/sycli/src/main.rs
+++ b/sycli/src/main.rs
@@ -336,28 +336,11 @@ fn main() {
 
     let client = match Client::new(url.clone()) {
         Ok(c) => c,
-        Err(_) => {
-            eprintln!("Failed to connect to synapse, ensure your URI and password are correct");
+        Err(e) => {
+            eprintln!("Failed to connect to synapse: {}", e);
             process::exit(1);
         }
     };
-
-    if client.version().major != rpc::MAJOR_VERSION {
-        eprintln!(
-            "synapse RPC major version {} is not compatible with sycli RPC major version {}",
-            client.version().major,
-            rpc::MAJOR_VERSION
-        );
-        process::exit(1);
-    }
-    if client.version().minor < rpc::MINOR_VERSION {
-        eprintln!(
-            "synapse RPC minor version {} is not compatible with sycli RPC minor version {}",
-            client.version().minor,
-            rpc::MINOR_VERSION
-        );
-        process::exit(1);
-    }
 
     if url.scheme() == "wss" {
         url.set_scheme("https").unwrap();


### PR DESCRIPTION
TODO: 
- [ ] Saving complete/download directories to session data
- [ ] RPC support
    - [ ] Sycli support

Please let me know what needs to be changed/added for this to be merged in (I'm pretty new to Rust, so I'm not quite confident with my code).

Also, what should I name the new session format version in `session/src/lib.rs`? I tried finding a pattern between the ones used until now, but it looks like random hex strings. Is that the case?