### PR TITLE
fix depreciated initializers for atomic variables

### DIFF
--- a/src/buffers.rs
+++ b/src/buffers.rs
@@ -3,7 +3,7 @@ use std::mem;
 use std::ops::{Deref, DerefMut};
 
 const MAX_BUFS: usize = 4096;
-static BUF_COUNT: atomic::AtomicUsize = atomic::ATOMIC_USIZE_INIT;
+static BUF_COUNT: atomic::AtomicUsize = atomic::AtomicUsize::new(0);
 
 #[derive(Clone)]
 pub struct Buffer {

--- a/src/main.rs
+++ b/src/main.rs
@@ -77,7 +77,7 @@ pub const UT_PEX_ID: u8 = 11;
 /// Throttler max token amount
 pub const THROT_TOKS: usize = 2 * 1024 * 1024;
 
-pub static SHUTDOWN: atomic::AtomicBool = atomic::ATOMIC_BOOL_INIT;
+pub static SHUTDOWN: atomic::AtomicBool = atomic::AtomicBool::new(false);
 
 lazy_static! {
     pub static ref CONFIG: config::Config = { config::Config::load() };


### PR DESCRIPTION
Fixes compilation warnings on rust >= 1.34.0.

See: 
- https://doc.rust-lang.org/std/sync/atomic/constant.ATOMIC_BOOL_INIT.html
- https://doc.rust-lang.org/std/sync/atomic/constant.ATOMIC_USIZE_INIT.html