### PR TITLE
Tweak picker, bitfield

### DIFF
--- a/src/torrent/mod.rs
+++ b/src/torrent/mod.rs
@@ -464,7 +464,7 @@ impl<T: cio::CIO> Torrent<T> {
                 piece_idx: self.info.piece_idx.clone(),
             },
             pieces: session::torrent::Bitfield {
-                data: self.pieces.data().clone(),
+                data: self.pieces.data(),
                 len: self.pieces.len(),
             },
             uploaded: self.uploaded,

--- a/src/torrent/picker/mod.rs
+++ b/src/torrent/picker/mod.rs
@@ -390,7 +390,7 @@ impl Picker {
             pieces,
             &vec![3u8; info.files.len()],
         );
-        p.change_picker(true, pieces);
+        p.change_picker(true);
         p
     }
 }


### PR DESCRIPTION
Saves a bit of memory with lazy allocations and fixes switching between pickers.

Closes #142 