### PR TITLE
Fix panicking unwrap() in choker

### DIFF
--- a/src/torrent/choker.rs
+++ b/src/torrent/choker.rs
@@ -108,11 +108,11 @@ impl Choker {
         let (slowest, _) = self.unchoked.iter().enumerate().fold(
             (0, ::std::u32::MAX),
             |(slowest, min), (idx, id)| {
-                let (_, dl) = peers.get_mut(id).unwrap().flush();
-                if dl < min {
-                    (idx, dl)
-                } else {
-                    (slowest, min)
+                match peers.get_mut(id).map(|peer| peer.flush()) {
+                    Some((_, dl)) if dl < min =>
+                        (idx, dl),
+                    _ =>
+                        (slowest, min),
                 }
             },
         );


### PR DESCRIPTION
I have seen the following panic:
```
thread 'control' panicked at 'called `Option::unwrap()` on a `None` value', src/libcore/option.rs:347:21
stack backtrace:
   0: std::sys_common::backtrace::print
   1: std::panicking::default_hook::{{closure}}
   2: std::panicking::default_hook
   3: std::panicking::rust_panic_with_hook
   4: std::panicking::continue_panic_fmt
   5: rust_begin_unwind
   6: core::panicking::panic_fmt
   7: core::panicking::panic
   8: synapse::torrent::choker::Choker::update_download
   9: <synapse::control::job::UnchokeUpdate as synapse::control::job::Job<T>>::update
  10: synapse::control::Control<T>::handle_event
  11: synapse::control::Control<T>::run
```

This commit prevents the panic for just one `.unwrap()`. I think there may be more locations where code like this can panic.