### PR TITLE
Upgrade sycli to Rust 2018 edition

### DIFF
--- a/sycli/Cargo.toml
+++ b/sycli/Cargo.toml
@@ -2,6 +2,7 @@
 name = "sycli"
 version = "0.1.0"
 authors = ["Luminarys <postmaster@gensok.io>"]
+edition = "2018"
 
 [dependencies]
 synapse-rpc = { path = "../rpc" }

--- a/sycli/src/client.rs
+++ b/sycli/src/client.rs
@@ -6,7 +6,7 @@ use ws::protocol::Message as WSMessage;
 
 use rpc::message::{CMessage, SMessage, Version};
 
-use error::{ErrorKind, Result, ResultExt};
+use crate::error::{ErrorKind, Result, ResultExt};
 
 pub struct Client {
     ws: ws::WebSocket<AutoStream>,

--- a/sycli/src/cmd.rs
+++ b/sycli/src/cmd.rs
@@ -131,7 +131,10 @@ fn del_torrent(c: &mut Client, torrent: &str, artifacts: bool) -> Result<()> {
         );
         for res in resources.into_iter().take(3) {
             if let Resource::Torrent(t) = res {
-                eprintln!("{}", t.name.unwrap_or("[Unknown Magnet]".to_owned()));
+                eprintln!(
+                    "{}",
+                    t.name.unwrap_or_else(|| "[Unknown Magnet]".to_owned())
+                );
             }
         }
     }
@@ -166,7 +169,10 @@ pub fn dl(mut c: Client, url: &str, name: &str) -> Result<()> {
         );
         for res in resources.into_iter().take(3) {
             if let Resource::Torrent(t) = res {
-                eprintln!("{}", t.name.unwrap_or("[Unknown Magnet]".to_owned()));
+                eprintln!(
+                    "{}",
+                    t.name.unwrap_or_else(|| "[Unknown Magnet]".to_owned())
+                );
             }
         }
         return Ok(());
@@ -346,7 +352,10 @@ fn pause_torrent(c: &mut Client, torrent: &str) -> Result<()> {
         );
         for res in resources.into_iter().take(3) {
             if let Resource::Torrent(t) = res {
-                eprintln!("{}", t.name.unwrap_or("[Unknown Magnet]".to_owned()));
+                eprintln!(
+                    "{}",
+                    t.name.unwrap_or_else(|| "[Unknown Magnet]".to_owned())
+                );
             }
         }
     }
@@ -377,7 +386,10 @@ fn resume_torrent(c: &mut Client, torrent: &str) -> Result<()> {
         );
         for res in resources.into_iter().take(3) {
             if let Resource::Torrent(t) = res {
-                eprintln!("{}", t.name.unwrap_or("[Unknown Magnet]".to_owned()));
+                eprintln!(
+                    "{}",
+                    t.name.unwrap_or_else(|| "[Unknown Magnet]".to_owned())
+                );
             }
         }
     }
@@ -435,7 +447,7 @@ pub fn watch(mut c: Client, id: &str, output: &str, completion: bool) -> Result<
         loop {
             if let SMessage::UpdateResources { resources, .. } = c.recv()? {
                 for r in resources {
-                    if let &SResourceUpdate::TorrentTransfer { progress, .. } = &r {
+                    if let SResourceUpdate::TorrentTransfer { progress, .. } = r {
                         if completion && progress == 1.0 {
                             return Ok(());
                         }
@@ -565,12 +577,7 @@ pub fn add_tags(mut c: Client, id: &str, tags: Vec<&str>) -> Result<()> {
             tag_array.push(t);
         }
     }
-    let tag_obj = json::Value::Array(
-        tag_array
-            .into_iter()
-            .map(|t| json::Value::String(t))
-            .collect(),
-    );
+    let tag_obj = json::Value::Array(tag_array.into_iter().map(json::Value::String).collect());
     resource.user_data = Some(json::json!({ "tags": tag_obj }));
     let msg = CMessage::UpdateResource {
         serial: c.next_serial(),
@@ -584,12 +591,7 @@ pub fn remove_tags(mut c: Client, id: &str, tags: Vec<&str>) -> Result<()> {
     let (id, mut tag_array) = get_tags_(&mut c, id)?;
     resource.id = id;
     tag_array.retain(|t| !tags.contains(&t.as_str()));
-    let tag_obj = json::Value::Array(
-        tag_array
-            .into_iter()
-            .map(|t| json::Value::String(t))
-            .collect(),
-    );
+    let tag_obj = json::Value::Array(tag_array.into_iter().map(json::Value::String).collect());
     resource.user_data = Some(json::json!({ "tags": tag_obj }));
     let msg = CMessage::UpdateResource {
         serial: c.next_serial(),
@@ -615,7 +617,7 @@ fn get_tags_(c: &mut Client, id: &str) -> Result<(String, Vec<String>)> {
         torrent.id.clone(),
         match prev_data.pointer("/tags") {
             Some(json::Value::Array(a)) => a
-                .into_iter()
+                .iter()
                 .filter_map(json::Value::as_str)
                 .map(|s| s.to_owned())
                 .collect(),
@@ -702,7 +704,7 @@ fn print_torrent_res(c: &mut Client, id: &str, kind: ResourceKind, output: &str)
 pub fn status(mut c: Client) -> Result<()> {
     match search(&mut c, ResourceKind::Server, vec![])?.pop() {
         Some(Resource::Server(s)) => {
-            let vi = s.id.find("-").unwrap();
+            let vi = s.id.find('-').unwrap();
             let version = &s.id[..vi];
             println!(
                 "synapse v{}, RPC v{}.{}",

--- a/sycli/src/cmd.rs
+++ b/sycli/src/cmd.rs
@@ -14,8 +14,8 @@ use rpc::criterion::{Criterion, Operation, Value};
 use rpc::message::{self, CMessage, SMessage};
 use rpc::resource::{CResourceUpdate, Resource, ResourceKind, SResourceUpdate, Server};
 
-use client::Client;
-use error::{ErrorKind, Result, ResultExt};
+use crate::client::Client;
+use crate::error::{ErrorKind, Result, ResultExt};
 
 pub fn add(
     mut c: Client,
@@ -571,7 +571,7 @@ pub fn add_tags(mut c: Client, id: &str, tags: Vec<&str>) -> Result<()> {
             .map(|t| json::Value::String(t))
             .collect(),
     );
-    resource.user_data = Some(json!({ "tags": tag_obj }));
+    resource.user_data = Some(json::json!({ "tags": tag_obj }));
     let msg = CMessage::UpdateResource {
         serial: c.next_serial(),
         resource,
@@ -590,7 +590,7 @@ pub fn remove_tags(mut c: Client, id: &str, tags: Vec<&str>) -> Result<()> {
             .map(|t| json::Value::String(t))
             .collect(),
     );
-    resource.user_data = Some(json!({ "tags": tag_obj }));
+    resource.user_data = Some(json::json!({ "tags": tag_obj }));
     let msg = CMessage::UpdateResource {
         serial: c.next_serial(),
         resource,

--- a/sycli/src/main.rs
+++ b/sycli/src/main.rs
@@ -458,7 +458,7 @@ fn main() {
                     let single_crit = serde_json::from_str(f).map(|c| vec![c]).ok();
                     single_crit.or_else(|| serde_json::from_str(f).ok())
                 })
-                .unwrap_or(vec![]);
+                .unwrap_or_else(Vec::new);
             let kind = args.value_of("kind").unwrap();
             let output = args.value_of("output").unwrap();
             let res = cmd::list(client, kind, crit, output);

--- a/sycli/src/main.rs
+++ b/sycli/src/main.rs
@@ -1,23 +1,13 @@
 #![allow(unused_doc_comments)]
 
-extern crate clap;
 #[macro_use]
 extern crate error_chain;
 #[macro_use]
 extern crate prettytable;
-extern crate reqwest;
-extern crate serde;
 #[macro_use]
 extern crate serde_derive;
-#[macro_use]
-extern crate serde_json;
-extern crate base64;
-extern crate openssl;
-extern crate shellexpand;
 extern crate synapse_rpc as rpc;
-extern crate toml;
 extern crate tungstenite as ws;
-extern crate url;
 
 mod client;
 mod cmd;


### PR DESCRIPTION
I was looking at the `sycli` code and my clippy had some warnings, and I saw that it wasn't 2018 edition yet. I decided to update it to Rust 2018 edition for now if you don't mind. I may have a future PR updating some of the dependencies. It didn't seem to break anything locally but please look over this and let me know of any issues.

Thanks.