### PR TITLE
Check some message lengths. Make Bitfield more robust.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -49,6 +49,11 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "assert_matches"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1499,6 +1504,7 @@ version = "1.0.0"
 dependencies = [
  "adns 0.1.0",
  "amy 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "assert_matches 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "base32 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "base64 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "bincode 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1967,6 +1973,7 @@ dependencies = [
 "checksum ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
 "checksum arrayref 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "0d382e583f07208808f6b1249e60848879ba3543f57c32277bf52d69c2f0f0ee"
 "checksum arrayvec 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "cff77d8686867eceff3105329d4698d96c2391c176d5d03adc90c7389162b5b8"
+"checksum assert_matches 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7deb0a829ca7bcfaf5da70b073a8d128619259a7be8216a355e23f00763059e5"
 "checksum atty 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)" = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
 "checksum autocfg 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "1d49d90015b3c36167a20fe2810c5cd875ad504b39cff3d4eae7977e6b7c1cb2"
 "checksum autocfg 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f8aac770f1885fd7e387acedd76065302551364496e46b3dd00860b2f8359b9d"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,6 +47,7 @@ adns = { path = "adns" }
 toml = "0.4"
 url = "1"
 getopts = "0.2"
+assert_matches = "1.3.0"
 
 [dependencies.amy]
 version = "0.10"

--- a/src/buffers.rs
+++ b/src/buffers.rs
@@ -4,7 +4,7 @@ use std::sync::atomic;
 use protocol;
 
 const MAX_BUFS: usize = 4096;
-const BUF_SIZE: usize = 16_384;
+pub const BUF_SIZE: usize = 16_384;
 static BUF_COUNT: atomic::AtomicUsize = atomic::AtomicUsize::new(0);
 
 #[derive(Clone)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -42,6 +42,10 @@ extern crate shellexpand;
 extern crate toml;
 extern crate url;
 
+#[cfg(test)]
+#[macro_use]
+extern crate assert_matches;
+
 extern crate adns;
 extern crate synapse_bencode as bencode;
 extern crate synapse_protocol as protocol;
@@ -50,6 +54,8 @@ extern crate synapse_session as session;
 
 #[macro_use]
 mod log;
+#[macro_use]
+mod util;
 mod args;
 mod buffers;
 mod config;
@@ -64,7 +70,6 @@ mod stat;
 mod throttle;
 mod torrent;
 mod tracker;
-mod util;
 
 // We need to do this for the log macros
 use log::LogLevel;

--- a/src/torrent/mod.rs
+++ b/src/torrent/mod.rs
@@ -1454,7 +1454,9 @@ impl<T: cio::CIO> Torrent<T> {
         self.pieces = Bitfield::new(u64::from(self.info.pieces()));
         self.priorities = Arc::new(vec![3; self.info.files.len()]);
         for peer in self.peers.values_mut() {
-            peer.magnet_complete(&self.info);
+            if !peer.magnet_complete(&self.info).is_ok() {
+                self.cio.remove_peer(peer.id());
+            }
         }
 
         let resources = self.rpc_rel_info();

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -157,6 +157,13 @@ pub fn find_subseq(haystack: &[u8], needle: &[u8]) -> Option<usize> {
         .position(|window| window == needle)
 }
 
+#[macro_export]
+macro_rules! div_round_up {
+    ($a:expr, $b:expr) => {
+        ($a + $b - 1) / $b
+    };
+}
+
 #[test]
 fn test_hash_enc() {
     let hash = [8u8; 20];


### PR DESCRIPTION
The code was panicking on some real packets it received:
1.  "Pieces" message, with length too big for the buffer.
2. "Bitfield" message with zero length. This was then "capped" (using Bitfield.cap) to the correct value *without allocating a bigger bitfield vector*. Then it crashed on a later "Have" message.

The first message check is easy. For the second, I made the "Bitfield" type more robust and added some more checks to the "cap" operations.
