### PR TITLE
add move as a subcommand to sycli torrent command

### DIFF
--- a/sycli/src/cmd.rs
+++ b/sycli/src/cmd.rs
@@ -461,6 +461,23 @@ pub fn watch(mut c: Client, id: &str, output: &str, completion: bool) -> Result<
     }
 }
 
+pub fn move_torrent(mut c: Client, id: &str, dir: &str) -> Result<()> {
+    let torrent = search_torrent_name(&mut c, id)?;
+    if torrent.len() != 1 {
+        bail!("Could not find appropriate torrent!");
+    }
+    let update = CMessage::UpdateResource {
+        serial: c.next_serial(),
+        resource: CResourceUpdate {
+            id: torrent[0].id().to_owned(),
+            path: Some(dir.to_owned()),
+            ..Default::default()
+        },
+    };
+    c.send(update)?;
+    Ok(())
+}
+
 pub fn add_trackers(mut c: Client, id: &str, trackers: Vec<&str>) -> Result<()> {
     let torrent = search_torrent_name(&mut c, id)?;
     if torrent.len() != 1 {

--- a/sycli/src/main.rs
+++ b/sycli/src/main.rs
@@ -221,6 +221,14 @@ fn main() {
                         .index(1),
                 )
                 .subcommands(vec![
+                    SubCommand::with_name("move")
+                        .about("Move a torrent to a new location")
+                        .arg(
+                            Arg::with_name("directory")
+                                .help("Directory to move the torrent to.")
+                                .index(1)
+                                .required(true),
+                        ),
                     SubCommand::with_name("tracker")
                         .about("Manipulate trackers for a torrent")
                         .subcommands(vec![
@@ -493,6 +501,17 @@ fn main() {
             let id = subcmd.value_of("torrent id").unwrap_or("none");
             let output = subcmd.value_of("output").unwrap();
             match subcmd.subcommand_name().unwrap() {
+                "move" => {
+                    let dir = subcmd
+                        .subcommand_matches("move")
+                        .unwrap()
+                        .value_of("directory")
+                        .unwrap();
+                    if let Err(e) = cmd::move_torrent(client, id, dir) {
+                        eprintln!("Failed to move torrent: {}", e.display_chain());
+                        process::exit(1);
+                    }
+                }
                 "tracker" => {
                     let sscmd = subcmd.subcommand_matches("tracker").unwrap();
                     match sscmd.subcommand_name().unwrap() {


### PR DESCRIPTION
this pr adds a move subcommand under the torrent menu so that sycli can now modify the path of a torrent.

while this works as intended, there is a strange side-effect that I don't know how to track down. on another terminal, I would use `sycli watch` to try and watch the update happen. It never worked, usually just keeping the old path. But sometimes it would jump to `./` even though that was never its path.

anyway, I still think its worthwhile to pull this in as long as you like the feature.

thanks for your work on this client! I've enjoyed reading through the source code looking to add these features.