### PR TITLE
Allow incoming peers to be pruned if they don't handshake.

### DIFF
--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -16,6 +16,7 @@ use rand::{self, Rng};
 pub type FHashMap<K, V> = fnv::FnvHashMap<K, V>;
 pub type FHashSet<T> = fnv::FnvHashSet<T>;
 pub type UHashMap<T> = FHashMap<usize, T>;
+pub type UHashSet = FHashSet<usize>;
 
 pub type MBuildHasher = BuildHasherDefault<MetroHash>;
 pub type MHashMap<K, V> = HashMap<K, V, MBuildHasher>;


### PR DESCRIPTION
Observed in the wild: sometimes peers connect but don't send any handshake. Over time this happens a lot and uses up all the file descriptors.

This change accepts a connection and then immediately gives it to cio. Then cio can prune it as necessary.
