### PR TITLE
Show individual files as complete after importing a torrent

### DIFF
--- a/src/torrent/mod.rs
+++ b/src/torrent/mod.rs
@@ -737,6 +737,8 @@ impl<T: cio::CIO> Torrent<T> {
                         info!("Invalid torrent imported, redownloading!");
                     }
                     self.announce_start();
+                    self.files.rebuild(&self.info, &self.pieces);
+                    self.update_rpc_transfer();
                     return;
                 }
                 if valid {


### PR DESCRIPTION
When adding a torrent with the import option, it would not show the individual files as complete.  I went through the code in the `disk::Response::ValidationComplete` function and found that adding `self.files.rebuild(&self.info, &self.pieces);` and `self.update_rpc_transfer();` make the files appear as complete. Adding `self.rpc_update_pieces();` and `self.announce_status();` had no effect, so I did not add them.