### PR TITLE
fixes install steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Install dependencies:
 Synapse and sycli can be installed with:
 ```
 cargo build --release --all
-cargo install
+cargo install --path .
 cargo install --path ./sycli/
 ```
 


### PR DESCRIPTION
This will fix the following error 

```
❯ cargo install
error: Using `cargo install` to install the binaries for the package in current working directory is no longer supported, use `cargo install --path .` instead. Use `cargo build` if you want to simply build the package
```