### PR TITLE
Increase tracker compatibility

### DIFF
--- a/src/tracker/http/reader.rs
+++ b/src/tracker/http/reader.rs
@@ -65,7 +65,7 @@ impl Reader {
         let mut header_done = None;
         match self.state {
             ReadState::Header => {
-                let mut headers = [httparse::EMPTY_HEADER; 16];
+                let mut headers = [httparse::EMPTY_HEADER; 32];
                 let mut resp = httparse::Response::new(&mut headers);
                 match resp.parse(&self.data[..self.idx]) {
                     Ok(httparse::Status::Complete(i)) => {

--- a/src/util/http.rs
+++ b/src/util/http.rs
@@ -75,7 +75,7 @@ impl<'a> RequestBuilder<'a> {
         }
         // The query either encodes an extra ? or an extra &, pop either off
         buf.pop();
-        buf.extend_from_slice(b" HTTP/1.1");
+        buf.extend_from_slice(b" HTTP/1.0");
         buf.extend_from_slice(b"\r\n");
         for header in &self.headers {
             buf.extend_from_slice(header.name.as_bytes());


### PR DESCRIPTION
Certain trackers will response more than 16 headers and causing the http parser to fail.
They will also use chunked encoding which confuses the bdecode. This patch will make the tracker client work properly with more trackers.