### PR TITLE
Support Non-UTF8 keys in Bencode dicts

### DIFF
--- a/src/torrent/peer/mod.rs
+++ b/src/torrent/peer/mod.rs
@@ -435,15 +435,18 @@ impl<T: cio::CIO> Peer<T> {
                     let mut d = b.into_dict().ok_or_else(|| {
                         ErrorKind::ProtocolError("Invalid bencode type in ext handshake")
                     })?;
-                    let mut m = d.remove("m").and_then(|v| v.into_dict()).ok_or_else(|| {
-                        ErrorKind::ProtocolError("Invalid metadata in in ext handshake")
-                    })?;
+                    let mut m = d
+                        .remove(b"m".as_ref())
+                        .and_then(|v| v.into_dict())
+                        .ok_or_else(|| {
+                            ErrorKind::ProtocolError("Invalid metadata in in ext handshake")
+                        })?;
                     self.ext_ids.ut_meta = m
-                        .remove("ut_metadata")
+                        .remove(b"ut_metadata".as_ref())
                         .and_then(|v| v.into_int())
                         .map(|v| v as u8);
                     self.ext_ids.ut_pex = m
-                        .remove("ut_pex")
+                        .remove(b"ut_pex".as_ref())
                         .and_then(|v| v.into_int())
                         .map(|v| v as u8);
                 }

--- a/src/tracker/mod.rs
+++ b/src/tracker/mod.rs
@@ -386,13 +386,13 @@ impl TrackerResponse {
         let mut d = data.into_dict().ok_or(ErrorKind::InvalidResponse(
             "Tracker response must be a dictionary type!",
         ))?;
-        if let Some(BEncode::String(data)) = d.remove("failure reason") {
+        if let Some(BEncode::String(data)) = d.remove(b"failure reason".as_ref()) {
             let reason = String::from_utf8(data)
                 .chain_err(|| ErrorKind::InvalidResponse("Failure reason must be UTF8!"))?;
             return Err(ErrorKind::TrackerError(reason).into());
         }
         let mut resp = TrackerResponse::empty();
-        if let Some(BEncode::String(ref data)) = d.remove("peers") {
+        if let Some(BEncode::String(ref data)) = d.remove(b"peers".as_ref()) {
             for p in data.chunks(6) {
                 if p.len() != 6 {
                     debug!("Unusual trailing bytes received for tracker!");
@@ -403,7 +403,7 @@ impl TrackerResponse {
                 resp.peers.push(SocketAddr::V4(socket));
             }
         }
-        match d.remove("interval") {
+        match d.remove(b"interval".as_ref()) {
             Some(BEncode::Int(ref i)) => {
                 resp.interval = *i as u32;
             }


### PR DESCRIPTION
This is necessary for #202 given that `piece layers` is a dictionary that uses non-utf8 keys.